### PR TITLE
switch algorithm to kawpow

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,7 +124,7 @@ public:
         consensus.nTimeSlotLength = 15;
         consensus.devAddress = "CCCdisabledXXXXXXXXXXXXXXXXXXXXXX";
 
-        consensus.nKAWPOWActivation = 1684250127;
+        consensus.nKAWPOWActivation = 1684857487;
 
         // spork key
         consensus.strSporkPubKey = "04638c049e470eee6fc99c6398018b183c21c4058e067be44ce88ae1f5d20519e11070a23101625050e4a159f1cff2c6d18218a0076b191e14b9c27df1c199cc6f";

--- a/src/version.h
+++ b/src/version.h
@@ -18,12 +18,11 @@ static const int PROTOCOL_VERSION = 70921;
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
+//! disconnect from peers older than this proto version
+static const int MIN_PEER_PROTO_VERSION = 70920;
+
 //! In this version, 'getheaders' was introduced.
 static const int GETHEADERS_VERSION = 70077;
-
-//! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = PROTOCOL_VERSION;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = PROTOCOL_VERSION;
 
 //! masternodes older than this proto version use old strMessage format for mnannounce
 static const int MIN_PEER_MNANNOUNCE = 70913;


### PR DESCRIPTION
this PR allows legacy clients to remain connected to the network, but will be disconnected once kawpow algorithm starts.